### PR TITLE
 new sphinx version introduces changes in sphinx.builders.html which cases docs json jobs to fail

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,2 +1,3 @@
 sphinxcontrib-serializinghtml===1.1.5
+# since version 7.2.0 the introduced changes in sphinx.builders.html (function setup_resource_paths) cause the json jobs fail
 sphinx===7.1.2

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,1 +1,2 @@
 sphinxcontrib-serializinghtml===1.1.5
+sphinx===7.1.2


### PR DESCRIPTION
since version 7.2.0 the json docs jobs fail with following error:

2023-08-18 06:18:06.384362 | fedora-pod | copying assets... copying static files... done
2023-08-18 06:18:06.384475 | fedora-pod | copying extra files... done
2023-08-18 06:18:06.384518 | fedora-pod | done
2023-08-18 06:18:06.400399 | fedora-pod | [2Kwriting output... [  1%] api_overview
2023-08-18 06:18:06.400415 | fedora-pod | Extension error (sphinx.builders.html):
2023-08-18 06:18:06.400420 | fedora-pod | Handler <function setup_resource_paths at 0x7f53885156c0> for event 'html-page-context' threw an exception (exception: 'pathto')
2023-08-18 06:18:07.014725 | fedora-pod | ERROR: InvocationError for command /root/src/gitea.eco.tsi-dev.otc-service.com/docs-swiss/relational-database-service/.tox/docs/bin/sphinx-build -W --keep-going -b json api-ref/source doc/build/json/api-ref (exited with code 2)

issue created on sphinx https://github.com/sphinx-doc/sphinx/issues/11615